### PR TITLE
Better support for multisize products

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,26 @@
                     <enableAssertions>false</enableAssertions>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.10</version>
+                <executions>
+                    <execution>
+                        <id>regex-property</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>snap.nbmSpecVersion</name>
+                            <value>${project.version}</value>
+                            <regex>-SNAPSHOT</regex>
+                            <replacement>.0</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>

--- a/src/main/java/org/esa/snap/dataio/ExpectedBand.java
+++ b/src/main/java/org/esa/snap/dataio/ExpectedBand.java
@@ -1,6 +1,7 @@
 package org.esa.snap.dataio;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.util.StringUtils;
@@ -9,12 +10,17 @@ import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Random;
 
+
 class ExpectedBand {
 
     @JsonProperty(required = true)
     private String name;
     @JsonProperty
     private String description;
+    @JsonProperty
+    private Integer bandWidth;
+    @JsonProperty
+    private Integer bandHeight;
     @JsonProperty
     private String geophysicalUnit;
     @JsonProperty
@@ -36,6 +42,8 @@ class ExpectedBand {
         this();
         this.name = band.getName();
         this.description = band.getDescription();
+        this.bandWidth = band.getRasterWidth();
+        this.bandHeight = band.getRasterHeight();
         this.geophysicalUnit = band.getUnit();
         this.noDataValue = String.valueOf(band.getGeophysicalNoDataValue());
         this.noDataValueUsed = String.valueOf(band.isNoDataValueUsed());
@@ -45,12 +53,15 @@ class ExpectedBand {
     }
 
     private ExpectedPixel[] createExpectedPixels(Band band, Random random) {
-        ArrayList<Point2D> pointList = ExpectedPixel.createPointList(band.getProduct(), random);
+        ArrayList<Point2D> pointList = ExpectedPixel.createPointList(band.getProduct(), band, random);
+
         final ExpectedPixel[] expectedPixels = new ExpectedPixel[pointList.size()];
         for (int i = 0; i < expectedPixels.length; i++) {
             final Point2D point = pointList.get(i);
+
             final int x = (int) point.getX();
             final int y = (int) point.getY();
+
             final float value = band.isPixelValid(x, y) ? band.getSampleFloat(x, y) : Float.NaN;
             expectedPixels[i] = new ExpectedPixel(x, y, value);
         }
@@ -67,6 +78,24 @@ class ExpectedBand {
 
     boolean isDescriptionSet() {
         return StringUtils.isNotNullAndNotEmpty(description);
+    }
+
+    int getBandWidth() {
+        return bandWidth;
+    }
+
+    @JsonIgnoreProperties
+    public boolean isBandWidthSet() {
+        return bandWidth != null;
+    }
+
+    int getBandHeight() {
+        return bandHeight;
+    }
+
+    @JsonIgnoreProperties()
+    public boolean isBandHeightSet() {
+        return bandHeight != null;
     }
 
     String getGeophysicalUnit() {

--- a/src/main/java/org/esa/snap/dataio/ExpectedContent.java
+++ b/src/main/java/org/esa/snap/dataio/ExpectedContent.java
@@ -76,7 +76,7 @@ public class ExpectedContent {
         final MetadataElement metadataRoot = product.getMetadataRoot();
         final List<ExpectedMetadata> expectedMetadata = new ArrayList<>();
         if (metadataRoot.getNumElements() > 0 || metadataRoot.getNumAttributes() > 0) {
-            while(expectedMetadata.size() < 2) {
+            while (expectedMetadata.size() < 10) {
                 MetadataElement currentElem = metadataRoot;
                 while (currentElem != null && currentElem.getNumElements() > 0) {
                     currentElem = currentElem.getElementAt((int) (currentElem.getNumElements() * random.nextFloat()));
@@ -98,6 +98,7 @@ public class ExpectedContent {
         return null;
     }
 
+
     private ExpectedMask[] createExpectedMasks(Product product) {
         final ProductNodeGroup<Mask> maskGroup = product.getMaskGroup();
         final List<ExpectedMask> expectedMasks = new ArrayList<>();
@@ -108,9 +109,9 @@ public class ExpectedContent {
                 expectedMasks.add(new ExpectedMask(mask));
             }
         }
-        if(expectedMasks.size() > 0) {
+        if (expectedMasks.size() > 0) {
             return expectedMasks.toArray(new ExpectedMask[expectedMasks.size()]);
-        }else {
+        } else {
             return null;
         }
     }

--- a/src/main/java/org/esa/snap/dataio/ExpectedGeoCoding.java
+++ b/src/main/java/org/esa/snap/dataio/ExpectedGeoCoding.java
@@ -27,7 +27,7 @@ class ExpectedGeoCoding {
 
     ExpectedGeoCoding(Product product, Random random) {
         this();
-        final ArrayList<Point2D> pointList = ExpectedPixel.createPointList(product, random);
+        final ArrayList<Point2D> pointList = ExpectedPixel.createPointList(product, null, random);
         final GeoCoding geoCoding = product.getSceneGeoCoding();
         coordinates = new ExpectedGeoCoordinate[pointList.size()];
         for (int i = 0; i < pointList.size(); i++) {

--- a/src/main/java/org/esa/snap/dataio/ExpectedPixel.java
+++ b/src/main/java/org/esa/snap/dataio/ExpectedPixel.java
@@ -1,6 +1,9 @@
 package org.esa.snap.dataio;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.esa.snap.core.datamodel.Band;
+import org.esa.snap.core.datamodel.GeoPos;
+import org.esa.snap.core.datamodel.PixelPos;
 import org.esa.snap.core.datamodel.PlacemarkGroup;
 import org.esa.snap.core.datamodel.Product;
 
@@ -38,17 +41,32 @@ class ExpectedPixel {
         return value;
     }
 
-    static ArrayList<Point2D> createPointList(Product product, Random random) {
+    static ArrayList<Point2D> createPointList(Product product, Band band, Random random) {
         ArrayList<Point2D> pointList = new ArrayList<>();
         if (product.getPinGroup().getNodeCount() > 0) {
             final PlacemarkGroup pinGroup = product.getPinGroup();
+            boolean transformPixelPosToBandGeocoding = (band != null) && (product.getSceneGeoCoding() != null) && (band.getGeoCoding() != null) && (product.getSceneGeoCoding() != band.getGeoCoding());
             for (int i = 0; i < pinGroup.getNodeCount(); i++) {
-                pointList.add(pinGroup.get(i).getPixelPos());
+                if (!transformPixelPosToBandGeocoding) {
+                    pointList.add(pinGroup.get(i).getPixelPos());
+                    continue;
+                }
+                PixelPos pixelScene = pinGroup.get(i).getPixelPos();
+                GeoPos geoPos = band.getProduct().getSceneGeoCoding().getGeoPos(new PixelPos(pixelScene.getX(), pixelScene.getY()), null);
+                PixelPos pixelInBand = band.getGeoCoding().getPixelPos(geoPos, null);
+                pointList.add(pixelInBand);
             }
         } else {
+            int width = product.getSceneRasterWidth();
+            int height = product.getSceneRasterHeight();
+            if (band != null) {
+                width = band.getRasterWidth();
+                height = band.getRasterHeight();
+            }
+
             for (int i = 0; i < 2; i++) {
-                final int x = (int) (random.nextFloat() * product.getSceneRasterWidth());
-                final int y = (int) (random.nextFloat() * product.getSceneRasterHeight());
+                final int x = (int) (random.nextFloat() * width);
+                final int y = (int) (random.nextFloat() * height);
                 pointList.add(new Point(x, y));
             }
         }

--- a/src/main/java/org/esa/snap/dataio/ExpectedTiePointGrid.java
+++ b/src/main/java/org/esa/snap/dataio/ExpectedTiePointGrid.java
@@ -109,7 +109,7 @@ class ExpectedTiePointGrid {
     }
 
     private ExpectedPixel[] createExpectedPixels(TiePointGrid tiePointGrid, Random random) {
-        final ArrayList<Point2D> pointList = ExpectedPixel.createPointList(tiePointGrid.getProduct(), random);
+        final ArrayList<Point2D> pointList = ExpectedPixel.createPointList(tiePointGrid.getProduct(), null, random);
         final ExpectedPixel[] expectedPixels = new ExpectedPixel[pointList.size()];
         for (int i = 0; i < expectedPixels.length; i++) {
             final Point2D point = pointList.get(i);

--- a/src/nbm/manifest.mf
+++ b/src/nbm/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module-Specification-Version: ${snap.nbmSpecVersion}
+AutoUpdate-Show-In-Client: true
+AutoUpdate-Essential-Module: false
+OpenIDE-Module-Java-Dependencies: Java > 1.8
+OpenIDE-Module-Display-Category: SNAP

--- a/src/test/java/org/esa/snap/dataio/ContentAssert.java
+++ b/src/test/java/org/esa/snap/dataio/ContentAssert.java
@@ -89,9 +89,9 @@ class ContentAssert {
                 if (reverseAccuracy >= 0) {
                     final PixelPos actualPixelPos = geoCoding.getPixelPos(actualGeoPos, null);
                     assertEquals(productId + " Pixel.X at GeoPos(" + actualGeoPos.getLat() + "," + actualGeoPos.getLon() + ")",
-                            expectedPixelPos.getX(), actualPixelPos.getX(), reverseAccuracy);
+                                 expectedPixelPos.getX(), actualPixelPos.getX(), reverseAccuracy);
                     assertEquals(productId + " Pixel.Y at GeoPos(" + actualGeoPos.getLat() + "," + actualGeoPos.getLon() + ")",
-                            expectedPixelPos.getY(), actualPixelPos.getY(), reverseAccuracy);
+                                 expectedPixelPos.getY(), actualPixelPos.getY(), reverseAccuracy);
                 }
             }
         }
@@ -116,12 +116,12 @@ class ContentAssert {
             final MetadataAttribute actualSample = actualSampleCoding.getAttribute(expectedSampleName);
             assertNotNull(msgPrefix + " sample '" + expectedSampleName + "' does not exist", actualSample);
             assertEquals(msgPrefix + " sample '" + expectedSampleName + "' Value",
-                    expectedSample.getValue(), actualSample.getData().getElemUInt());
+                         expectedSample.getValue(), actualSample.getData().getElemUInt());
 
             final String expectedSampleDescription = expectedSample.getDescription();
             if (StringUtils.isNotNullAndNotEmpty(expectedSampleDescription)) {
                 assertEquals(msgPrefix + " sample '" + expectedSampleName + "' Description",
-                        expectedSampleDescription, actualSample.getDescription());
+                             expectedSampleDescription, actualSample.getDescription());
             }
         }
     }
@@ -195,6 +195,14 @@ class ContentAssert {
             Assert.assertEquals(messagePrefix + " Description", expectedBand.getDescription(), band.getDescription());
         }
 
+        if (expectedBand.isBandWidthSet()) {
+            Assert.assertEquals(messagePrefix + " BandWidth", expectedBand.getBandWidth(), band.getRasterWidth());
+        }
+
+        if (expectedBand.isBandHeightSet()) {
+            Assert.assertEquals(messagePrefix + " BandHeight", expectedBand.getBandHeight(), band.getRasterHeight());
+        }
+
         if (expectedBand.isGeophysicalUnitSet()) {
             Assert.assertEquals(messagePrefix + " Unit", expectedBand.getGeophysicalUnit(), band.getUnit());
         }
@@ -225,19 +233,6 @@ class ContentAssert {
             int pixelY = pixel.getY();
             String pixelString = " Pixel(" + pixel.getX() + "," + pixel.getY() + ")";
             try {
-                if (product.isMultiSize() && product.isSceneCrsASharedModelCrs()) {
-                    // todo - [multiSize] it is not generic enough but sufficient for now (mp - 20151120)
-                    final MathTransform sceneI2mTransform = product.getSceneGeoCoding().getImageToMapTransform();
-                    final AffineTransform bandM2iTransform = band.getImageToModelTransform().createInverse();
-
-                    final DirectPosition2D sceneModelPos = new DirectPosition2D();
-                    sceneI2mTransform.transform(new DirectPosition2D(pixelX, pixelY), sceneModelPos);
-                    final DirectPosition2D bandImagePos = new DirectPosition2D();
-                    bandM2iTransform.transform(sceneModelPos, bandImagePos);
-                    pixelX = (int) Math.floor(bandImagePos.getX());
-                    pixelY = (int) Math.floor(bandImagePos.getY());
-                    pixelString = pixelString + " transf(" + pixelX + "," + pixelY + ")";
-                }
                 float bandValue;
                 if (band.isPixelValid(pixelX, pixelY)) {
                     bandValue = band.getSampleFloat(pixelX, pixelY);
@@ -249,7 +244,7 @@ class ContentAssert {
                 final StringWriter stackTraceWriter = new StringWriter();
                 e.printStackTrace(new PrintWriter(stackTraceWriter));
                 Assert.fail(messagePrefix + pixelString + "- caused " + e.getClass().getSimpleName() + "\n" +
-                            stackTraceWriter.toString());
+                                    stackTraceWriter.toString());
             }
         }
     }
@@ -259,7 +254,7 @@ class ContentAssert {
         assertEquals(msgPrefix + " Color", expectedMask.getColor(), actualMask.getImageColor());
         final String expectedMaskDescription = expectedMask.getDescription();
         if (StringUtils.isNotNullAndNotEmpty(expectedMaskDescription)) {
-            assertEquals(msgPrefix + " Description",expectedMaskDescription, actualMask.getDescription());
+            assertEquals(msgPrefix + " Description", expectedMaskDescription, actualMask.getDescription());
         }
     }
 

--- a/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
+++ b/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
@@ -162,9 +162,9 @@ public class ProductReaderAcceptanceTest {
                             logger.info(INDENT + INDENT + stopWatch.getTimeDiffString() + " - [" + expected + "] " + testProduct.getId());
                         }
                         testCounter++;
-                    }else if(!DecodeQualification.UNABLE.equals(decodeQualification)){
+                    } else if (!DecodeQualification.UNABLE.equals(decodeQualification)) {
                         logger.info(INDENT + INDENT + productReaderPlugin.getClass().getSimpleName() + ": " +
-                                    "Can read " + testProduct.getId() + "[" + decodeQualification + "] but it is not defined in tests");
+                                            "Can read " + testProduct.getId() + "[" + decodeQualification + "] but it is not defined in tests");
                     }
                 } else {
                     logProductNotExistent(2, testProduct);
@@ -195,7 +195,8 @@ public class ProductReaderAcceptanceTest {
                 if (testProduct.exists()) {
                     final File testProductFile = getTestProductFile(testProduct);
 
-                    final ProductReader productReader = testDefinition.getProductReaderPlugin().createReaderInstance();
+                    final ProductReader productReader =testDefinition.getProductReaderPlugin().createReaderInstance();
+
                     stopWatch.start();
                     final Product product = productReader.readProductNodes(testProductFile, null);
                     try {
@@ -260,10 +261,10 @@ public class ProductReaderAcceptanceTest {
     public void testProductReadTimes() throws Exception {
         logInfoWithStars("Testing product read times");
         logger.info(String.format("%s%s - %s - %s - %s", INDENT,
-                " findReader ",
-                " readNodes  ",
-                "   getStx   ",
-                " getViewData"));
+                                  " findReader ",
+                                  " readNodes  ",
+                                  "   getStx   ",
+                                  " getViewData"));
         final StopWatch stopWatchTotal = new StopWatch();
         stopWatchTotal.start();
         int testCounter = 0;
@@ -278,6 +279,7 @@ public class ProductReaderAcceptanceTest {
                     //product = ProductIO.readProduct(testProductFile);
                     // method inlined for detailed time measuring
                     final ProductReader productReader = ProductIO.getProductReaderForInput(testProductFile);
+
                     stopWatch.stop();
                     String findProductReaderTime = stopWatch.getTimeDiffString();
 
@@ -294,13 +296,11 @@ public class ProductReaderAcceptanceTest {
                             stopWatch.start();
                             Stx stx = band0.getStx();
                             errorCollector.checkThat("stx != null:" + testProduct.getId(), stx, is(notNullValue()));
-
                             stopWatch.stop();
                             getStxTime = stopWatch.getTimeDiffString();
                             DefaultViewport viewport = new DefaultViewport(new Rectangle(1000, 1000));
                             int viewLevel = ImageLayer.getLevel(band0.getSourceImage().getModel(), viewport);
                             RenderedImage viewImage = band0.getSourceImage().getImage(viewLevel);
-
                             stopWatch.start();
                             final int numXTiles = viewImage.getNumXTiles();
                             final int numYTiles = viewImage.getNumYTiles();
@@ -320,11 +320,11 @@ public class ProductReaderAcceptanceTest {
                         }
                     }
                     logger.info(String.format("%s%s - %s - %s - %s - %s", INDENT,
-                            findProductReaderTime,
-                            readProductNodesTime,
-                            getStxTime,
-                            getViewDataTime,
-                            testProduct.getId()));
+                                              findProductReaderTime,
+                                              readProductNodesTime,
+                                              getStxTime,
+                                              getViewDataTime,
+                                              testProduct.getId()));
                 } catch (Exception e) {
                     final String message = "Product reading " + testProduct.getId() + " caused an exception.";
                     logger.log(Level.SEVERE, message, e);

--- a/src/test/resources/org/esa/snap/visat/actions/EXPECTED_JSON_CODE.json
+++ b/src/test/resources/org/esa/snap/visat/actions/EXPECTED_JSON_CODE.json
@@ -27,6 +27,8 @@
             {
                 "name": "band_1",
                 "description": "description_1",
+                "bandWidth": 10,
+                "bandHeight": 20,
                 "geophysicalUnit": "abc",
                 "noDataValue": "1.0",
                 "noDataValueUsed": "true",
@@ -48,6 +50,8 @@
             {
                 "name": "band_2",
                 "description": "description_2",
+                "bandWidth": 10,
+                "bandHeight": 20,
                 "geophysicalUnit": "m/w^2",
                 "noDataValue": "0.0",
                 "noDataValueUsed": "false",
@@ -71,6 +75,38 @@
             {
                 "path": "test_1/ABC[3]/Name",
                 "value": "ABC_3"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
             },
             {
                 "path": "test_2/attrib[2]",

--- a/src/test/resources/org/esa/snap/visat/actions/EXPECTED_JSON_PINS_CODE.json
+++ b/src/test/resources/org/esa/snap/visat/actions/EXPECTED_JSON_PINS_CODE.json
@@ -27,6 +27,8 @@
             {
                 "name": "band_1",
                 "description": "description_1",
+                "bandWidth": 10,
+                "bandHeight": 20,
                 "geophysicalUnit": "abc",
                 "noDataValue": "1.0",
                 "noDataValueUsed": "true",
@@ -48,6 +50,8 @@
             {
                 "name": "band_2",
                 "description": "description_2",
+                "bandWidth": 10,
+                "bandHeight": 20,
                 "geophysicalUnit": "m/w^2",
                 "noDataValue": "0.0",
                 "noDataValueUsed": "false",
@@ -75,6 +79,38 @@
             {
                 "path": "test_2/attrib[3]",
                 "value": "ghi"
+            },
+            {
+                "path": "test_1/ABC[2]/Name",
+                "value": "ABC_2"
+            },
+            {
+                "path": "test_1/ABC/Name",
+                "value": "ABC_1"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_2/attrib[2]",
+                "value": "def"
+            },
+            {
+                "path": "test_1/ABC/Name",
+                "value": "ABC_1"
+            },
+            {
+                "path": "test_2/attrib",
+                "value": "abc"
+            },
+            {
+                "path": "test_2/attrib",
+                "value": "abc"
+            },
+            {
+                "path": "test_1/ABC[3]/Name",
+                "value": "ABC_3"
             }
         ]
     }


### PR DESCRIPTION
- when generating expected point list, ensure (x,y)
  coordinates fall into the band image bounds
- reprojection from scene CRS to band CRS is required
  when using pins, because pins coordinates are stored
  in the scene CRS
- number of extracted metadata set to 10 instead of 2
- verify individual band width/height, in addition to scene width/height