### PR TITLE
[SNAP-1247] NetCDF library logs a lot of useless warnings

### DIFF
--- a/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
+++ b/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
@@ -88,6 +88,7 @@ public class ProductReaderAcceptanceTest {
     @BeforeClass
     public static void initialize() throws Exception {
         initLogger();
+        SystemUtils.init3rdPartyLibs(ProductReaderAcceptanceTest.class);
 
         logFailOnMissingDataMessage();
 
@@ -400,9 +401,6 @@ public class ProductReaderAcceptanceTest {
     }
 
     private static void initLogger() throws Exception {
-        // Suppress ugly (and harmless) JAI error messages saying that a JAI is going to continue in pure Java mode.
-        System.setProperty("com.sun.media.jai.disableMediaLib", "true");  // disable native libraries for JAI
-
         logger = Logger.getLogger(ProductReaderAcceptanceTest.class.getSimpleName());
         removeRootLogHandler();
         final ConsoleHandler consoleHandler = new ConsoleHandler();


### PR DESCRIPTION
Calling SystemUtils.init3rdPartyLibs() ensures that libs are configured the same way as when running SNAP.
Also removed config of JAI media lib usage. This is already done in the init3rdPartyLibs method.