### PR TITLE
GDAL: Move the invocation of GDAL initialisation from constructor to …

### DIFF
--- a/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
+++ b/src/test/java/org/esa/snap/dataio/ProductReaderAcceptanceTest.java
@@ -20,7 +20,6 @@ package org.esa.snap.dataio;
 import com.bc.ceres.glayer.support.ImageLayer;
 import com.bc.ceres.grender.support.DefaultViewport;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.esa.s2tbx.dataio.gdal.GDALLoader;
 import org.esa.snap.core.dataio.DecodeQualification;
 import org.esa.snap.core.dataio.ProductIO;
 import org.esa.snap.core.dataio.ProductReader;
@@ -99,7 +98,6 @@ public class ProductReaderAcceptanceTest {
 
         createGlobalProductList();
 
-        GDALLoader.getInstance().initGDAL();
         OpenJPEGInstaller.install();
 
         new NetCdfActivator().start();

--- a/src/test/java/org/esa/snap/gpt/RunGPTProductReaderTest.java
+++ b/src/test/java/org/esa/snap/gpt/RunGPTProductReaderTest.java
@@ -1,7 +1,6 @@
 package org.esa.snap.gpt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.esa.s2tbx.dataio.gdal.GDALLoader;
 import org.esa.snap.core.dataio.ProductIO;
 import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.gpf.main.GPT;
@@ -12,7 +11,6 @@ import org.esa.snap.dataio.ExpectedContent;
 import org.esa.snap.dataio.ExpectedDataset;
 import org.esa.snap.dataio.ProductReaderAcceptanceTest;
 import org.esa.snap.lib.openjpeg.activator.OpenJPEGInstaller;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -48,7 +46,6 @@ public class RunGPTProductReaderTest {
     public static void initialize() throws Exception {
         initLogger();
 
-        GDALLoader.getInstance().initGDAL();
         OpenJPEGInstaller.install();
     }
 


### PR DESCRIPTION
GDAL: Move the invocation of GDAL initialisation from constructor to static block to ensure that the GDAL is initialized before operating with any GDAL reader/writer. So the invocation of GDAL initialisation from classes who use GDAL reader/writer is no longer be needed.