### PR TITLE
dependencies to snap should use snap.version variable and not project…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,26 +210,26 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-raster</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-raster</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -816,4 +816,3 @@
         </plugins>
     </reporting>
 </project>
-


### PR DESCRIPTION
Dependencies to snap should use snap.version variable in the pom and not project.version. Using project.version causes wrong version of SNAP to be included.